### PR TITLE
feat(db): integrate PostgreSQL and expose price history API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.8'
+
+services:
+
+  db:
+    image: postgres:16
+    container_name: crypto_postgres
+    restart: always
+
+    # WARNING: These credentials are for development only.
+    environment:
+      POSTGRES_DB: crypto_exchange
+      POSTGRES_USER: crypto_user
+      POSTGRES_PASSWORD: crypto_pass
+    ports:
+      - "5432:5432"
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+
+volumes:
+  pg_data:

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,19 @@
 		<java.version>21</java.version>
 	</properties>
 	<dependencies>
+
+		<!-- JPA and PostgreSQL -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<version>42.7.3</version>
+		</dependency>
+
+
 		<!-- Jackson for JSON parsing -->
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/java/com/crypto/exchange/prices/controller/PriceHistoryController.java
+++ b/src/main/java/com/crypto/exchange/prices/controller/PriceHistoryController.java
@@ -1,0 +1,27 @@
+package com.crypto.exchange.prices.controller;
+
+
+import com.crypto.exchange.prices.dto.PricePointDTO;
+import com.crypto.exchange.prices.service.PriceHistoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/prices/history")
+@RequiredArgsConstructor
+public class PriceHistoryController {
+    private final PriceHistoryService priceHistoryService;
+
+    @GetMapping
+    public List<PricePointDTO> getPriceHistory(
+            @RequestParam String cryptoCode,
+            @RequestParam(defaultValue = "USD") String fiatCode,
+            @RequestParam(defaultValue = "24h") String range
+    ) {
+        return priceHistoryService.getDownsampledHistory(cryptoCode, fiatCode, range);
+    }
+}

--- a/src/main/java/com/crypto/exchange/prices/db/model/PriceEntity.java
+++ b/src/main/java/com/crypto/exchange/prices/db/model/PriceEntity.java
@@ -1,0 +1,24 @@
+package com.crypto.exchange.prices.db.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+@Entity
+@Table(name = "crypto_prices")
+@Getter
+@Setter
+public class PriceEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String cryptoCode; // e.g., BTC, ETH
+    private String fiatCode; // e.g., USD
+    private BigDecimal price;
+    private Instant timestamp;
+}

--- a/src/main/java/com/crypto/exchange/prices/db/projection/DownsampledPriceProjection.java
+++ b/src/main/java/com/crypto/exchange/prices/db/projection/DownsampledPriceProjection.java
@@ -1,0 +1,8 @@
+package com.crypto.exchange.prices.db.projection;
+
+import java.time.Instant;
+
+public interface DownsampledPriceProjection {
+    Instant getBucket();
+    Double getAvgPrice();
+}

--- a/src/main/java/com/crypto/exchange/prices/db/repository/PriceHistoryRepository.java
+++ b/src/main/java/com/crypto/exchange/prices/db/repository/PriceHistoryRepository.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface PriceRepository extends JpaRepository<PriceEntity, Long> {
+public interface PriceHistoryRepository extends JpaRepository<PriceEntity, Long> {
 
     @Query(value = """
         SELECT 

--- a/src/main/java/com/crypto/exchange/prices/db/repository/PriceRepository.java
+++ b/src/main/java/com/crypto/exchange/prices/db/repository/PriceRepository.java
@@ -1,0 +1,32 @@
+package com.crypto.exchange.prices.db.repository;
+
+import com.crypto.exchange.prices.db.model.PriceEntity;
+import com.crypto.exchange.prices.db.projection.DownsampledPriceProjection;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PriceRepository extends JpaRepository<PriceEntity, Long> {
+
+    @Query(value = """
+        SELECT 
+          date_trunc(:interval, timestamp) AS bucket,
+          AVG(price) AS avg_price
+        FROM crypto_prices
+        WHERE crypto_code = :cryptoCode
+          AND fiat_code = :fiatCode
+          AND timestamp >= NOW() - CAST(:range AS INTERVAL)
+        GROUP BY bucket
+        ORDER BY bucket
+    """, nativeQuery = true)
+    List<DownsampledPriceProjection> getDownsampledPrices(
+            @Param("cryptoCode") String cryptoCode,
+            @Param("fiatCode") String fiatCode,
+            @Param("interval") String interval,
+            @Param("range") String range
+    );
+}

--- a/src/main/java/com/crypto/exchange/prices/dto/PricePointDTO.java
+++ b/src/main/java/com/crypto/exchange/prices/dto/PricePointDTO.java
@@ -1,0 +1,6 @@
+package com.crypto.exchange.prices.dto;
+
+import java.time.Instant;
+
+public record PricePointDTO (Instant timestamp, Double price) {
+}

--- a/src/main/java/com/crypto/exchange/prices/service/CryptoPriceService.java
+++ b/src/main/java/com/crypto/exchange/prices/service/CryptoPriceService.java
@@ -29,6 +29,13 @@ public class CryptoPriceService {
         return price != null ? price : -1.0;
     }
 
+
+
+
+
+
+
+
     public CryptoPriceRecord getExampleLatestPrices() {
         Map<String, Double> btcPrices = new HashMap<>();
         btcPrices.put("USD", 70000.99);

--- a/src/main/java/com/crypto/exchange/prices/service/PriceHistoryService.java
+++ b/src/main/java/com/crypto/exchange/prices/service/PriceHistoryService.java
@@ -1,0 +1,28 @@
+package com.crypto.exchange.prices.service;
+
+import com.crypto.exchange.prices.db.repository.PriceHistoryRepository;
+import com.crypto.exchange.prices.dto.PricePointDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PriceHistoryService {
+    public final PriceHistoryRepository priceHistoryRepository;
+
+    public List<PricePointDTO> getDownsampledHistory(String cryptoCode, String fiatCode, String range) {
+        String interval = switch (range) {
+            case "1h" -> "minute";
+            case "6h", "24h" -> "10 minutes";
+            case "7d" -> "hour";
+            case "30d" -> "4 hours";
+            case "1y" -> "day";
+            default -> throw new IllegalArgumentException("Unsupported range: " + range);
+        };
+
+        return priceHistoryRepository.getDownsampledPrices(cryptoCode, fiatCode, interval, range).stream()
+                .map(p -> new PricePointDTO(p.getBucket(), p.getAvgPrice()))
+                .toList();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=prices

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,17 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/crypto_exchange
+    username: crypto_user
+    password: crypto_pass
+
+  jpa:
+    hibernate:
+      ddl-auto: update         # Creates or updates tables based on @Entity classes
+    show-sql: true             # Prints SQL statements in the console
+    properties:
+      hibernate:
+        format_sql: true       # Formats printed SQL for easier reading
+
+  application:
+    name: prices-module
+


### PR DESCRIPTION
### Summary

This pull request introduces PostgreSQL integration into the Prices module and provides an HTTP endpoint for retrieving historical cryptocurrency price data.

---

### Changes

- Added PostgreSQL dependencies and configuration (`application.yml`, `docker-compose.yml`)
- Replaced `application.properties` with `application.yml`
- Defined `PriceEntity` for storing price records
- Created `DownsampledPriceProjection` for time-bucketed queries
- Implemented `PriceHistoryRepository` and `PriceHistoryService`
- Added `PricePointDTO` for API responses
- Introduced `PriceHistoryController` with `/api/prices/history` endpoint

---

### Notes

- The database is not yet pre-populated with data; future work will handle historical data seeding and sync logic
- Caching and validation are not yet implemented
- API currently assumes default fiat as `USD` and default range as `24h` if not provided

---

### Next Steps (in future PRs)

- Fetch and persist historical data from CoinGecko
- Sync prices on application startup or via scheduled jobs
- Add support for caching and input validation
